### PR TITLE
also cache gradle itself

### DIFF
--- a/.github/workflows/build_and_test.yml
+++ b/.github/workflows/build_and_test.yml
@@ -31,6 +31,10 @@ jobs:
       # An ordered list of keys to use for restoring the cache if no cache hit occurred for key
         restore-keys: |
           ${{ runner.os }}-gradle-
+    - uses: actions/cache@v1.1.2
+      with:
+        path: ~/.gradle/wrapper
+        key: ${{ runner.os }}-gradle-wrapper-${{ hashFiles('gradle/wrapper/gradle-wrapper.properties') }}
     # Runs a single command using the runners shell
     - name: build and test
       run: ./gradlew spotlessCheck test


### PR DESCRIPTION
this PR moves external artifacts list into a json file so that we can change them w/o re-deployment