### PR TITLE
Handle errors when adding dependencies

### DIFF
--- a/ideplugin/src/main/kotlin/com/birbit/artifactfinder/ideplugin/VersionSelectionPopupController.kt
+++ b/ideplugin/src/main/kotlin/com/birbit/artifactfinder/ideplugin/VersionSelectionPopupController.kt
@@ -77,12 +77,13 @@ class VersionSelectionPopupController(
     private fun addToGradle(version: String, module: Module, includeProcessor: Boolean) {
         val dependencyUtil = BuildDependencyHandler(module)
         val artifact = result.qualifiedArtifact(version)
-        dependencyUtil.addMavenDependency(artifact,
+        dependencyUtil.addMavenDependency(
+            coordinate = artifact,
             onSuccess = {
-                showNotification("Added $artifact to ${module.name}'s dependencies")
+                showNotification("Added $artifact to ${module.name}'s dependencies.")
             },
-            onError = {
-                showError("Unable to add $artifact to ${module.name}'s dependencies")
+            onError = { msg ->
+                showError("Unable to add $artifact to ${module.name}'s dependencies. $msg")
             })
     }
 


### PR DESCRIPTION
This PR changes dependency handler to check for existing
artifacts and issue an update if it already exists.

It now also shows an error if a newer version already exists
or dependency cannot be added for whatever reason.

Unfortunately, this change requires going through the gradle
API rather than the generic API as generic API does not provide
an option to update dependency. A nice side effect is that
the gradle api also allows sync